### PR TITLE
Changed RJava to rJava

### DIFF
--- a/topic-modelling/deps.R
+++ b/topic-modelling/deps.R
@@ -4,7 +4,7 @@ cranRepo <- "http://cran.ma.imperial.ac.uk/"
 install.packages("tm", repos=cranRepo)
 install.packages("topicmodels", repos=cranRepo)
 install.packages("SnowballC", repos=cranRepo)
-install.packages("RJava", repos=cranRepo)
+install.packages("rJava", repos=cranRepo)
 install.packages("devtools", repos=cranRepo)
 install.packages("stringi", repos=cranRepo)
 install.packages("dplyr", repos=cranRepo)


### PR DESCRIPTION
When trying to install dependencies, R prompts users to check the name of the RJava dependency and change it to rJava. This changes the name of the dependency to rJava so that this error does not appear and the script runs smoothly.